### PR TITLE
Update aca-revision.yml

### DIFF
--- a/.github/workflows/aca-revision.yml
+++ b/.github/workflows/aca-revision.yml
@@ -19,6 +19,7 @@ on:
 permissions:
       id-token: write
       contents: read
+      
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,10 +28,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Login to Azure
-      uses: azure/login@v2
+    - name: 'Az CLI login'
+      uses: azure/login@v1
       with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     - name: Restart ContainerApp with revision ${{ github.event.inputs.revname }}
       uses: azure/CLI@v1


### PR DESCRIPTION
Here are the key changes:

* [`.github/workflows/aca-revision.yml`](diffhunk://#diff-ad6538e02e353225f8de90bb532a929db4eea0068dc44e3ed0438b2299a437f0L30-R36): Removed the 'Login to Azure' step under `jobs:` and replaced it with 'Az CLI login' step. The new login step uses version 1 of the Azure login action and includes new parameters for `client-id`, `tenant-id`, and `subscription-id`.
* [`.github/workflows/aca-revision.yml`](diffhunk://#diff-ad6538e02e353225f8de90bb532a929db4eea0068dc44e3ed0438b2299a437f0R22): Added a new line under `permissions:` in the `on:` section for formatting purposes.